### PR TITLE
Add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '20 6 * * 1'
 


### PR DESCRIPTION
Adds a manual trigger to the CI workflow so it can be run on demand to test changes (e.g. the new weekly schedule) without waiting for the cron.